### PR TITLE
Fix client for recent versions of node.js.

### DIFF
--- a/lib/api_client.js
+++ b/lib/api_client.js
@@ -27,7 +27,7 @@
         host: this.AWS_US_EAST_HOST,
         port: 443,
         api_version: 1,
-        user_agent: this.version,
+        user_agent: this.version(),
         queue_name: 'default'
       };
       APIClient.__super__.constructor.call(this, 'iron', 'mq', options, defaultOptions, ['project_id', 'token', 'api_version', 'queue_name']);

--- a/src/api_client.coffee
+++ b/src/api_client.coffee
@@ -15,7 +15,7 @@ class APIClient extends ironCore.Client
       host: @AWS_US_EAST_HOST,
       port: 443,
       api_version: 1,
-      user_agent: @version,
+      user_agent: @version(),
       queue_name: 'default'
 
     super('iron', 'mq', options, defaultOptions, ['project_id', 'token', 'api_version', 'queue_name'])


### PR DESCRIPTION
Recent version of Node insist that all request headers be
strings, which causes the iron mq client to break.
