### PR TITLE
Fixed mistake in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Default is 0 seconds. Maximum is 604,800 seconds (7 days).
 ### Delete a Message from a Queue
 
 ```javascript
-queue.delete(message_id, callback(error, body) {});
+queue.del(message_id, callback(error, body) {});
 ```
 
 Be sure to delete a message from the queue when you're done with it.


### PR DESCRIPTION
The README claimed that messages could be deleted with queue.delete(), when it should actually be queue.del(). Hopefully this will save somebody from confusion. Otherwise, node + iron.io rocks!
